### PR TITLE
Add checksumResource snippet

### DIFF
--- a/core/components/checksumfile/elements/snippets/checksumResource.snippet.php
+++ b/core/components/checksumfile/elements/snippets/checksumResource.snippet.php
@@ -1,0 +1,15 @@
+<?php
+$id = $modx->getOption('id', $scriptProperties, '');
+if (empty($id)) return '';
+
+$resource = $modx->getObject('modResource', $id);
+if ($resource) {
+    $date = $resource->get('editedon');
+    $date = ($date) ? $date : $resource->get('createdon');
+    $checksum = hash('crc32b', $date);
+    if (!empty($checksum)) { 
+        $url = $modx->makeUrl($id);
+        return substr_replace($url, '.'.$checksum.'.', strrpos($url, '.'), 1);
+    }
+} 
+return $modx->makeUrl($id);


### PR DESCRIPTION
This snippet will generate the URL to a MODX resource with a checksum on base of the editedon/createdon timestamp for cachebusting (i.e. to use generated script files by a MODX resource).